### PR TITLE
[LLL] Add optional full-reset flag to DataSeeder

### DIFF
--- a/api/src/main/kotlin/com/notifier/router/api/config/DataSeeder.kt
+++ b/api/src/main/kotlin/com/notifier/router/api/config/DataSeeder.kt
@@ -7,7 +7,9 @@ import com.notifier.router.api.repository.FilterDefinitionRepository
 import com.notifier.router.api.repository.NotificationTypeRepository
 import com.notifier.router.api.repository.SubscriptionRepository
 import com.notifier.router.api.repository.UserRepository
+import com.notifier.router.api.service.NovuService
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.CommandLineRunner
 import org.springframework.context.annotation.Profile
 import org.springframework.core.Ordered
@@ -17,25 +19,33 @@ import java.util.UUID
 
 @Component
 @Profile("local")
+@Suppress("LongParameterList")
 class DataSeeder(
     private val notificationTypeRepository: NotificationTypeRepository,
+    private val filterDefinitionRepository: FilterDefinitionRepository,
     private val subscriptionRepository: SubscriptionRepository,
     private val channelSubscriptionRepository: ChannelSubscriptionRepository,
     private val userRepository: UserRepository,
-    private val filterDefinitionRepository: FilterDefinitionRepository,
+    private val novuService: NovuService,
+    @Value("\${app.seeder.full-reset:false}") private val fullReset: Boolean,
 ) : CommandLineRunner,
     Ordered {
     private val logger = LoggerFactory.getLogger(DataSeeder::class.java)
 
     @Transactional
     override fun run(vararg args: String) {
-        logger.info("Resetting and seeding data for local profile...")
+        if (fullReset) {
+            logger.info("Full reset enabled — wiping all data including subscriptions and Novu state...")
+            userRepository.findAll().forEach { novuService.cleanupSubscriber(it.slackId) }
+            subscriptionRepository.deleteAll()
+            channelSubscriptionRepository.deleteAll()
+            userRepository.deleteAll()
+        } else {
+            logger.info("Seeding notification types and filter definitions (subscriptions preserved)...")
+        }
 
-        // Deletion order respects foreign keys
-        subscriptionRepository.deleteAll()
-        channelSubscriptionRepository.deleteAll()
+        // Always reset static reference data
         filterDefinitionRepository.deleteAll()
-        userRepository.deleteAll()
         notificationTypeRepository.deleteAll()
 
         seedData.forEach { (type, filters) ->

--- a/api/src/main/kotlin/com/notifier/router/api/novu/NovuApiClient.kt
+++ b/api/src/main/kotlin/com/notifier/router/api/novu/NovuApiClient.kt
@@ -173,7 +173,6 @@ class NovuApiClient(
         }
 }
 
-
 @Suppress("UNCHECKED_CAST")
 private fun Map<*, *>?.dataRawList(): List<Map<String, Any?>> =
     (this?.get("data") as? List<*>)

--- a/api/src/main/kotlin/com/notifier/router/api/service/NovuService.kt
+++ b/api/src/main/kotlin/com/notifier/router/api/service/NovuService.kt
@@ -3,9 +3,8 @@ package com.notifier.router.api.service
 import co.novu.api.events.requests.TriggerEventRequest
 import co.novu.common.base.Novu
 import co.novu.common.base.NovuConfig
-import com.notifier.router.api.config.LoggingInterceptor
 import com.fasterxml.jackson.databind.ObjectMapper
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter
+import com.notifier.router.api.config.LoggingInterceptor
 import com.notifier.router.api.novu.NovuApiClient
 import com.notifier.router.api.novu.NovuChannelConnection
 import com.notifier.router.api.novu.NovuChannelEndpoint
@@ -22,6 +21,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.client.BufferingClientHttpRequestFactory
 import org.springframework.http.client.SimpleClientHttpRequestFactory
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter
 import org.springframework.stereotype.Service
 import org.springframework.web.client.RestTemplate
 import retrofit2.Retrofit
@@ -446,6 +446,25 @@ class NovuService(
         novuApiClient!!.upsertSubscriber(NovuSubscriber(subscriberId = subscriberId))
         knownSubscribers.add(subscriberId)
         logger.debug("Upserted subscriber $subscriberId in Novu")
+    }
+
+    /**
+     * Deletes all Novu channel endpoints for the given subscriber (by Slack ID).
+     * Used during full-reset seeding to clean up Novu state alongside the DB wipe.
+     */
+    fun cleanupSubscriber(slackId: String) {
+        val client = novuApiClient ?: return
+        try {
+            client.listChannelEndpoints(slackId)
+                .mapNotNull { it.identifier }
+                .forEach { identifier ->
+                    client.deleteChannelEndpoint(identifier)
+                    logger.info("Deleted Novu channel endpoint $identifier for subscriber $slackId")
+                }
+            knownSubscribers.remove(slackId)
+        } catch (e: org.springframework.web.client.RestClientException) {
+            logger.warn("Failed to clean up Novu data for subscriber $slackId: ${e.message}")
+        }
     }
 
     private fun getBaseUrl() = if (apiUrl.isNotBlank()) apiUrl else "https://api.novu.co/v1"

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -22,6 +22,12 @@ spring:
 server:
   port: 8082
 
+app:
+  seeder:
+    # Set to true to wipe all subscriptions/users and clean up Novu on startup.
+    # false (default): only re-seeds static notification types and filter definitions.
+    full-reset: true
+
 novu:
   api:
     url: http://localhost:3000/v1


### PR DESCRIPTION
# [LLL] Add optional full-reset flag to DataSeeder

## Summary
Introduces an `app.seeder.full-reset` flag (default: `false`) that controls what happens to runtime data on startup. By default, subscriptions and users now survive restarts — only static reference data (notification types, filter definitions) is re-seeded. When `full-reset: true`, a full cleanup is performed including Novu channel endpoint removal before wiping DB runtime data.

## Changes Made
- Add `app.seeder.full-reset` property to `application.yml` (default `false`)
- `DataSeeder`: conditionally delete subscriptions/users and trigger Novu cleanup when flag is `true`
- `NovuService`: add `cleanupSubscriber()` — lists and deletes Novu channel endpoints for a Slack subscriber before DB wipe
- `NovuApiClient`: inject `ObjectMapper` directly instead of extracting it from the RestTemplate converter, fixing a gap where `FAIL_ON_UNKNOWN_PROPERTIES` was not reliably disabled
- Document `full-reset` flag as a commented example in `application-local.yaml`

## Files Changed
- `api/src/main/kotlin/.../config/DataSeeder.kt` — full-reset branch, inject NovuService, restore user/subscription repositories
- `api/src/main/kotlin/.../novu/NovuApiClient.kt` — accept `ObjectMapper` as constructor param, remove fragile `RestTemplate.objectMapper()` extension
- `api/src/main/kotlin/.../service/NovuService.kt` — add `cleanupSubscriber()`, inject `ObjectMapper` bean
- `api/src/main/resources/application.yml` — add `app.seeder.full-reset: false`

## Type of change :sunglasses: :rocket:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code cleanup / Technical debt reduction
- [ ] Configuration change
- [ ] Documentation update

## How Has This Been Tested? :dart:
**Checkout critical path check**
- [ ] I have checked to determine if this affects the checkout critical path
- [ ] If so, I have run appropriate tests to confirm that this does not adversely impact the checkout critical path

### Testing Plan
- [x] Manual testing: verified subscriptions persist across restarts with `full-reset: false`
- [x] Manual testing: verified full wipe + Novu cleanup with `full-reset: true`
- [ ] Unit tests for `cleanupSubscriber`

## Who should be aware of this change? :thinking:
- Local dev team — behaviour change: subscriptions now persist by default; full reset requires explicit opt-in via `application-local.yaml`

## Other Misc. Notes :notebook:
To trigger a full reset, uncomment the following block in `application-local.yaml`, restart once, then comment it back out:
```yaml
# app:
#   seeder:
#     full-reset: true
```