### PR TITLE
fix: match any /notifyme* slash command variant via regex pattern

### DIFF
--- a/bot/src/main/kotlin/com/notifier/router/bot/handlers/SlashCommandHandlers.kt
+++ b/bot/src/main/kotlin/com/notifier/router/bot/handlers/SlashCommandHandlers.kt
@@ -28,7 +28,7 @@ class SlashCommandHandlers(
 
     @PostConstruct
     fun registerHandlers() {
-        app.command("/notifyme") { req: SlashCommandRequest, ctx: SlashCommandContext ->
+        app.command("/notifyme.*".toPattern()) { req: SlashCommandRequest, ctx: SlashCommandContext ->
             handleCommand(req, ctx)
         }
 


### PR DESCRIPTION
Allows teams to use custom command names (e.g. /notifymejuan) by registering the handler with a Pattern instead of an exact string.