### PR TITLE
[LLL] Fix NovuApiClientTest and NovuServiceTest missing objectMapper parameter

### DIFF
--- a/api/src/test/kotlin/com/notifier/router/api/novu/NovuApiClientTest.kt
+++ b/api/src/test/kotlin/com/notifier/router/api/novu/NovuApiClientTest.kt
@@ -1,5 +1,6 @@
 package com.notifier.router.api.novu
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
@@ -39,7 +40,7 @@ class NovuApiClientTest {
             RestTemplate().apply {
                 messageConverters.add(0, MappingJackson2HttpMessageConverter())
             }
-        client = NovuApiClient(restTemplate, "${wm.baseUrl()}/v1", "test-key")
+        client = NovuApiClient(restTemplate, "${wm.baseUrl()}/v1", "test-key", ObjectMapper())
     }
 
     @AfterAll

--- a/api/src/test/kotlin/com/notifier/router/api/service/NovuServiceTest.kt
+++ b/api/src/test/kotlin/com/notifier/router/api/service/NovuServiceTest.kt
@@ -1,6 +1,7 @@
 package com.notifier.router.api.service
 
 import co.novu.common.base.Novu
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.notifier.router.api.novu.NovuApiClient
 import com.notifier.router.api.novu.NovuChannelConnection
 import com.notifier.router.api.novu.NovuChannelEndpoint
@@ -33,6 +34,7 @@ class NovuServiceTest {
                 slackBotToken = "xoxb-token",
                 slackWorkspaceId = "T123",
                 slackWorkspaceName = "Test Workspace",
+                objectMapper = ObjectMapper(),
             )
         val field = NovuService::class.java.getDeclaredField("novuApiClient")
         field.isAccessible = true


### PR DESCRIPTION
# [LLL] Fix NovuApiClientTest and NovuServiceTest missing objectMapper parameter

## Summary
Both `NovuApiClientTest` and `NovuServiceTest` were failing to compile because they were instantiating `NovuApiClient` and `NovuService` without the `objectMapper` constructor parameter that was added after the tests were originally written. This caused CI to fail with \"No value passed for parameter 'objectMapper'\".

## Changes Made
- Pass `ObjectMapper()` to `NovuApiClient` constructor in `NovuApiClientTest`
- Pass `objectMapper = ObjectMapper()` to `NovuService` constructor in `NovuServiceTest`
- Add `import com.fasterxml.jackson.databind.ObjectMapper` to both test files

## Files Changed
- `api/src/test/kotlin/com/notifier/router/api/novu/NovuApiClientTest.kt` - added missing `ObjectMapper` import and constructor argument
- `api/src/test/kotlin/com/notifier/router/api/service/NovuServiceTest.kt` - added missing `ObjectMapper` import and constructor argument

## Type of change :sunglasses: :rocket:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code cleanup / Technical debt reduction
- [ ] Dependency change
- [ ] Configuration change
- [ ] Documentation update

## How Has This Been Tested? :dart:
**Checkout critical path check**
- [ ] I have checked to determine if this affects the checkout critical path

### Testing Plan
- [x] Verified `./gradlew check --no-daemon` passes locally with no compilation errors or test failures

## Who should be aware of this change? :thinking:
- No specific stakeholders — this is a pure test compilation fix.

## Other Misc. Notes :notebook:
No functional code changes. Tests were already correct in their assertions; they just needed the `objectMapper` argument added to match the updated constructors.