### PR TITLE
feat: implement DELETE /api/v1/subscriptions/{id} with 404 and Novu cleanup

### DIFF
--- a/api/src/main/kotlin/com/notifier/router/api/controller/GlobalExceptionHandler.kt
+++ b/api/src/main/kotlin/com/notifier/router/api/controller/GlobalExceptionHandler.kt
@@ -1,5 +1,6 @@
 package com.notifier.router.api.controller
 
+import com.notifier.router.api.exception.SubscriptionNotFoundException
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -9,6 +10,12 @@ import org.springframework.web.bind.annotation.RestControllerAdvice
 @RestControllerAdvice
 class GlobalExceptionHandler {
     private val logger = LoggerFactory.getLogger(GlobalExceptionHandler::class.java)
+
+    @ExceptionHandler(SubscriptionNotFoundException::class)
+    fun handleSubscriptionNotFound(ex: SubscriptionNotFoundException): ResponseEntity<Unit> {
+        logger.warn("Subscription not found: ${ex.message}")
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).build()
+    }
 
     @ExceptionHandler(Exception::class)
     fun handleGeneralException(ex: Exception): ResponseEntity<Unit> {

--- a/api/src/main/kotlin/com/notifier/router/api/service/SubscriptionService.kt
+++ b/api/src/main/kotlin/com/notifier/router/api/service/SubscriptionService.kt
@@ -82,7 +82,21 @@ class SubscriptionService(
 
     @Transactional
     fun deleteSubscription(id: String) {
-        subscriptionRepository.deleteById(UUID.fromString(id))
+        val uuid = UUID.fromString(id)
+        val subscription = subscriptionRepository.findById(uuid).orElse(null)
+            ?: throw SubscriptionNotFoundException("Subscription not found: $id")
+
+        subscriptionRepository.deleteById(uuid)
+
+        val remaining = subscriptionRepository.findByUserId(subscription.userId)
+        if (remaining.isEmpty()) {
+            val user = userRepository.findById(subscription.userId).orElse(null) ?: return
+            try {
+                novuService.cleanupSubscriber(user.slackId)
+            } catch (e: org.springframework.web.client.RestClientException) {
+                logger.warn("Could not clean up Novu data for subscriber ${user.slackId}", e)
+            }
+        }
     }
 
     @Transactional(readOnly = true)

--- a/api/src/test/kotlin/com/notifier/router/api/controller/SubscriptionControllerTest.kt
+++ b/api/src/test/kotlin/com/notifier/router/api/controller/SubscriptionControllerTest.kt
@@ -1,12 +1,15 @@
 package com.notifier.router.api.controller
 
+import com.notifier.router.api.exception.SubscriptionNotFoundException
 import com.notifier.router.api.service.SubscriptionService
 import com.notifier.router.common.dto.SubscriptionDto
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.whenever
 import org.springframework.http.HttpStatus
 
@@ -100,5 +103,16 @@ class SubscriptionControllerTest {
 
         assert(result.statusCode == HttpStatus.NO_CONTENT)
         assert(result.body == null)
+    }
+
+    @Test
+    fun `test deleteSubscription propagates SubscriptionNotFoundException`() {
+        val id = "${java.util.UUID.randomUUID()}"
+        doThrow(SubscriptionNotFoundException("Subscription not found: $id"))
+            .whenever(subscriptionService).deleteSubscription(any())
+
+        assertThrows<SubscriptionNotFoundException> {
+            subscriptionController.deleteSubscription(id)
+        }
     }
 }

--- a/api/src/test/kotlin/com/notifier/router/api/service/SubscriptionServiceTest.kt
+++ b/api/src/test/kotlin/com/notifier/router/api/service/SubscriptionServiceTest.kt
@@ -133,12 +133,71 @@ class SubscriptionServiceTest {
     }
 
     @Test
-    fun `test deleteSubscription deletes subscription`() {
+    fun `test deleteSubscription deletes subscription and cleans up Novu when last subscription`() {
+        val id = UUID.randomUUID()
+        val userUuid = UUID.randomUUID()
+        val slackId = "U12345"
+        val subscription = Subscription(
+            id = id,
+            userId = userUuid,
+            notificationTypeId = UUID.randomUUID(),
+            channels = listOf("slack_dm"),
+            channelConfig = emptyMap(),
+            filters = emptyList(),
+            enabled = true,
+        )
+        val mockUser = User(id = userUuid, slackId = slackId)
+
+        whenever(subscriptionRepository.findById(id)).thenReturn(Optional.of(subscription))
+        whenever(subscriptionRepository.findByUserId(userUuid)).thenReturn(emptyList())
+        whenever(userRepository.findById(userUuid)).thenReturn(Optional.of(mockUser))
+
+        subscriptionService.deleteSubscription(id.toString())
+
+        verify(subscriptionRepository).deleteById(id)
+        verify(novuService).cleanupSubscriber(slackId)
+    }
+
+    @Test
+    fun `test deleteSubscription does not clean up Novu when other subscriptions remain`() {
+        val id = UUID.randomUUID()
+        val userUuid = UUID.randomUUID()
+        val subscription = Subscription(
+            id = id,
+            userId = userUuid,
+            notificationTypeId = UUID.randomUUID(),
+            channels = listOf("slack_dm"),
+            channelConfig = emptyMap(),
+            filters = emptyList(),
+            enabled = true,
+        )
+        val remaining = Subscription(
+            id = UUID.randomUUID(),
+            userId = userUuid,
+            notificationTypeId = UUID.randomUUID(),
+            channels = listOf("slack_dm"),
+            channelConfig = emptyMap(),
+            filters = emptyList(),
+            enabled = true,
+        )
+
+        whenever(subscriptionRepository.findById(id)).thenReturn(Optional.of(subscription))
+        whenever(subscriptionRepository.findByUserId(userUuid)).thenReturn(listOf(remaining))
+
+        subscriptionService.deleteSubscription(id.toString())
+
+        verify(subscriptionRepository).deleteById(id)
+        verify(novuService, org.mockito.Mockito.never()).cleanupSubscriber(any())
+    }
+
+    @Test
+    fun `test deleteSubscription throws exception when subscription not found`() {
         val id = UUID.randomUUID().toString()
+        whenever(subscriptionRepository.findById(UUID.fromString(id))).thenReturn(Optional.empty())
 
-        subscriptionService.deleteSubscription(id)
-
-        verify(subscriptionRepository).deleteById(UUID.fromString(id))
+        assertThrows<SubscriptionNotFoundException> {
+            subscriptionService.deleteSubscription(id)
+        }
     }
 
     @Test


### PR DESCRIPTION
Closes #2

## Summary
- `DELETE /api/v1/subscriptions/{id}` now returns **404** when the subscription does not exist (via `SubscriptionNotFoundException`)
- After deletion, cleans up **Novu channel endpoints** via `NovuService.cleanupSubscriber` when the user has no remaining subscriptions
- Added `SubscriptionNotFoundException` handler in `GlobalExceptionHandler` → 404 response

## Test plan
- [x] `SubscriptionServiceTest`: delete with Novu cleanup (last subscription), delete without cleanup (remaining subscriptions exist), 404 when not found
- [x] `SubscriptionControllerTest`: 204 on success, propagates `SubscriptionNotFoundException` to caller
- [x] `detekt` passes with no violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)