### PR TITLE
feat: allow multiple subscriptions to same event type with different filters

### DIFF
--- a/api/src/main/kotlin/com/notifier/router/api/controller/GlobalExceptionHandler.kt
+++ b/api/src/main/kotlin/com/notifier/router/api/controller/GlobalExceptionHandler.kt
@@ -19,9 +19,18 @@ class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(DataIntegrityViolationException::class)
-    fun handleDataIntegrityViolation(ex: DataIntegrityViolationException): ResponseEntity<Unit> {
+    fun handleDataIntegrityViolation(ex: DataIntegrityViolationException): ResponseEntity<Map<String, String>> {
         logger.warn("Data integrity violation: ${ex.message}")
-        return ResponseEntity.status(HttpStatus.CONFLICT).build()
+        val message = when {
+            ex.message?.contains("uc_subscription_user_type_filters") == true ->
+                "You already have a subscription to this event type with the same filters."
+            ex.message?.contains("uc_channel_sub_channel_type_filters") == true ->
+                "This channel already has a subscription to this event type with the same filters."
+            ex.message?.contains("uc_user_slack_id") == true ->
+                "A user with this Slack ID already exists."
+            else -> "A record with these values already exists."
+        }
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(mapOf("error" to message))
     }
 
     @ExceptionHandler(Exception::class)

--- a/api/src/main/kotlin/com/notifier/router/api/domain/ChannelSubscription.kt
+++ b/api/src/main/kotlin/com/notifier/router/api/domain/ChannelSubscription.kt
@@ -7,7 +7,6 @@ import jakarta.persistence.EntityListeners
 import jakarta.persistence.Id
 import jakarta.persistence.Index
 import jakarta.persistence.Table
-import jakarta.persistence.UniqueConstraint
 import jakarta.validation.constraints.NotBlank
 import org.hibernate.annotations.JdbcTypeCode
 import org.hibernate.type.SqlTypes
@@ -19,13 +18,6 @@ import java.util.UUID
 @Entity
 @Table(
     name = "channel_subscriptions",
-    uniqueConstraints =
-    [
-        UniqueConstraint(
-            name = "uc_channel_sub_channel_type",
-            columnNames = ["slack_channel_id", "notification_type_id"],
-        ),
-    ],
     indexes =
     [
         Index(name = "idx_channel_sub_channel_id", columnList = "slack_channel_id"),

--- a/api/src/main/kotlin/com/notifier/router/api/domain/Subscription.kt
+++ b/api/src/main/kotlin/com/notifier/router/api/domain/Subscription.kt
@@ -7,7 +7,6 @@ import jakarta.persistence.EntityListeners
 import jakarta.persistence.Id
 import jakarta.persistence.Index
 import jakarta.persistence.Table
-import jakarta.persistence.UniqueConstraint
 import org.hibernate.annotations.JdbcTypeCode
 import org.hibernate.type.SqlTypes
 import org.springframework.data.annotation.CreatedDate
@@ -19,13 +18,6 @@ import java.util.UUID
 @Entity
 @Table(
     name = "subscriptions",
-    uniqueConstraints =
-    [
-        UniqueConstraint(
-            name = "uc_subscription_user_type",
-            columnNames = ["user_id", "notification_type_id"],
-        ),
-    ],
     indexes =
     [
         Index(name = "idx_subscription_user_id", columnList = "user_id"),

--- a/api/src/main/kotlin/com/notifier/router/api/repository/ChannelSubscriptionRepository.kt
+++ b/api/src/main/kotlin/com/notifier/router/api/repository/ChannelSubscriptionRepository.kt
@@ -9,11 +9,6 @@ import java.util.UUID
 interface ChannelSubscriptionRepository : JpaRepository<ChannelSubscription, UUID> {
     fun findBySlackChannelId(slackChannelId: String): List<ChannelSubscription>
 
-    fun findBySlackChannelIdAndNotificationTypeId(
-        slackChannelId: String,
-        notificationTypeId: UUID,
-    ): ChannelSubscription?
-
     fun findByNotificationTypeId(notificationTypeId: UUID): List<ChannelSubscription>
 
     fun findBySlackChannelIdAndEnabledTrue(slackChannelId: String): List<ChannelSubscription>

--- a/api/src/main/kotlin/com/notifier/router/api/repository/SubscriptionRepository.kt
+++ b/api/src/main/kotlin/com/notifier/router/api/repository/SubscriptionRepository.kt
@@ -9,11 +9,6 @@ import java.util.UUID
 interface SubscriptionRepository : JpaRepository<Subscription, UUID> {
     fun findByUserId(userId: UUID): List<Subscription>
 
-    fun findByUserIdAndNotificationTypeId(
-        userId: UUID,
-        notificationTypeId: UUID,
-    ): Subscription?
-
     fun findByNotificationTypeId(notificationTypeId: UUID): List<Subscription>
 
     fun findByUserIdAndEnabledTrue(userId: UUID): List<Subscription>

--- a/api/src/main/resources/db/migration/V2__Allow_duplicate_subscription_type.sql
+++ b/api/src/main/resources/db/migration/V2__Allow_duplicate_subscription_type.sql
@@ -1,0 +1,11 @@
+-- Allow multiple subscriptions to the same event type with different filters.
+-- Replace the old unique constraint (user + type) with one that includes a hash
+-- of the filters, so duplicates are only blocked when the filters are identical.
+
+ALTER TABLE subscriptions DROP CONSTRAINT uc_subscription_user_type;
+CREATE UNIQUE INDEX uc_subscription_user_type_filters
+    ON subscriptions (user_id, notification_type_id, md5(filters::text));
+
+ALTER TABLE channel_subscriptions DROP CONSTRAINT uc_channel_sub_channel_type;
+CREATE UNIQUE INDEX uc_channel_sub_channel_type_filters
+    ON channel_subscriptions (slack_channel_id, notification_type_id, md5(filters::text));

--- a/api/src/main/resources/static/dashboard.html
+++ b/api/src/main/resources/static/dashboard.html
@@ -451,7 +451,12 @@ function toast(msg, type = 'success') {
 
 async function apiFetch(path, opts = {}) {
   const res = await fetch(API + path, { headers: { 'Content-Type': 'application/json', ...opts.headers }, ...opts });
-  if (!res.ok) { const text = await res.text(); throw new Error(text || res.statusText); }
+  if (!res.ok) {
+    const text = await res.text();
+    let msg = res.statusText;
+    try { const json = JSON.parse(text); msg = json.error || json.message || text; } catch { msg = text || res.statusText; }
+    throw new Error(msg);
+  }
   if (res.status === 204 || res.status === 202) return null;
   return res.json();
 }

--- a/api/src/main/resources/static/index.html
+++ b/api/src/main/resources/static/index.html
@@ -1012,7 +1012,9 @@ async function api(path, opts = {}) {
   });
   if (!res.ok) {
     const text = await res.text();
-    throw new Error(text || res.statusText);
+    let msg = res.statusText;
+    try { const json = JSON.parse(text); msg = json.error || json.message || text; } catch { msg = text || res.statusText; }
+    throw new Error(msg);
   }
   if (res.status === 204 || res.status === 202) return null;
   return res.json();


### PR DESCRIPTION
## Summary
- **Drop unique constraint** `(user_id, notification_type_id)` on subscriptions and `(slack_channel_id, notification_type_id)` on channel subscriptions
- **Replace with filter-aware unique index** using `md5(filters::text)` — users can now subscribe to the same event type multiple times with different filters (e.g. `deploy_completed` for `service: balances` AND `service: treasury`)
- **Descriptive error messages** when attempting to create a duplicate subscription with identical filters (409 Conflict with human-readable JSON)
- **UI error parsing** — both dashboards now parse JSON error responses and show the message in toast notifications

## Changes
| File | Change |
|------|--------|
| `V2__Allow_duplicate_subscription_type.sql` | New migration: drop old constraints, create filter-aware unique indexes |
| `Subscription.kt` | Remove `UniqueConstraint` annotation |
| `ChannelSubscription.kt` | Remove `UniqueConstraint` annotation |
| `SubscriptionRepository.kt` | Remove unused `findByUserIdAndNotificationTypeId` |
| `ChannelSubscriptionRepository.kt` | Remove unused `findBySlackChannelIdAndNotificationTypeId` |
| `GlobalExceptionHandler.kt` | Return descriptive JSON error on 409 Conflict |
| `dashboard.html` | Parse JSON error responses in API fetch |
| `index.html` | Parse JSON error responses in API fetch |

## Test plan
- [ ] Subscribe to `deploy_completed` with filter `service EQ balances` — succeeds
- [ ] Subscribe to `deploy_completed` with filter `service EQ treasury` — succeeds (different filters)
- [ ] Subscribe to `deploy_completed` with filter `service EQ balances` again — fails with "You already have a subscription to this event type with the same filters."
- [ ] Same behavior for channel subscriptions
- [ ] Send test events — both subscriptions trigger independently

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)