### PR TITLE
feat: include PR link in pr_created Slack notification

### DIFF
--- a/api/src/main/kotlin/com/notifier/router/api/domain/NotificationEvent.kt
+++ b/api/src/main/kotlin/com/notifier/router/api/domain/NotificationEvent.kt
@@ -28,7 +28,7 @@ data class PrCreatedEvent(
     override val payload
         get() =
             mapOf<String, Any>(
-                "content" to "PR opened by $author: $title ($repo)",
+                "content" to "PR opened by $author: <$url|$title> ($repo)",
                 "title" to title,
                 "description" to description,
                 "url" to url,


### PR DESCRIPTION
## Summary
- `pr_created` Slack notification now includes a clickable link to the PR using Slack mrkdwn format `<url|title>`
- Before: `PR opened by author: Title (repo)`
- After: `PR opened by author: <url|Title> (repo)`

## Test plan
- [x] Open a PR in the repo
- [ ] Verify the Slack notification message contains a clickable link to the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)