### PR TITLE
feat: make PR title a clickable link in pr_created Slack notification

### DIFF
--- a/api/src/main/kotlin/com/notifier/router/api/service/NovuService.kt
+++ b/api/src/main/kotlin/com/notifier/router/api/service/NovuService.kt
@@ -275,7 +275,7 @@ class NovuService(
             val hasPushStep = steps.any { it.template.type == "push" }
             val hasWrongTemplate = steps.any {
                 when (it.template.type) {
-                    "chat" -> it.template.content != "{{content}}"
+                    "chat" -> it.template.content != "{{{content}}}"
                     "email" ->
                         it.template.content != "{{content}}" ||
                             it.template.contentType != "customHtml" ||
@@ -306,7 +306,7 @@ class NovuService(
                     steps =
                     listOf(
                         NovuWorkflowStep(NovuStepTemplate("in_app", "{{content}}")),
-                        NovuWorkflowStep(NovuStepTemplate("chat", "{{content}}")),
+                        NovuWorkflowStep(NovuStepTemplate("chat", "{{{content}}}")),
                         NovuWorkflowStep(NovuStepTemplate("email", "{{content}}", "customHtml", "{{subject}}")),
                     ),
                     active = true,
@@ -336,14 +336,14 @@ class NovuService(
                 .filter { it.template.type != "push" }
                 .map {
                     when (it.template.type) {
-                        "chat" -> NovuWorkflowStep(NovuStepTemplate("chat", "{{content}}"))
+                        "chat" -> NovuWorkflowStep(NovuStepTemplate("chat", "{{{content}}}"))
                         "email" -> NovuWorkflowStep(
                             NovuStepTemplate("email", "{{content}}", "customHtml", "{{subject}}")
                         )
                         else -> it
                     }
                 }
-                .let { if (!hasChatStep) it + NovuWorkflowStep(NovuStepTemplate("chat", "{{content}}")) else it }
+                .let { if (!hasChatStep) it + NovuWorkflowStep(NovuStepTemplate("chat", "{{{content}}}")) else it }
                 .let {
                     if (!hasEmailStep) {
                         it + NovuWorkflowStep(NovuStepTemplate("email", "{{content}}", "customHtml", "{{subject}}"))


### PR DESCRIPTION
## Summary
- `pr_created` Slack notification now shows the PR title as a clickable mrkdwn link: `PR opened by author: <url|title> (repo)`
- Root cause of previous failure: Handlebars `{{content}}` was HTML-escaping `<` and `>` before sending to Slack, causing `<url|text>` to render literally. Fixed by using `{{{content}}}` (triple-brace = no escaping) in Novu workflow step templates
- Existing Novu workflows are auto-patched on API startup when the chat step still uses the old escaped template

## Test plan
- [ ] Open a PR and verify the Slack notification shows the PR title as a clickable hyperlink

🤖 Generated with [Claude Code](https://claude.com/claude-code)