### PR TITLE
feat(api): handle Buildkite ping event and add buildkite_ping notific…

### DIFF
--- a/api/src/main/kotlin/com/notifier/router/api/adapter/BuildkiteWebhookAdapter.kt
+++ b/api/src/main/kotlin/com/notifier/router/api/adapter/BuildkiteWebhookAdapter.kt
@@ -23,6 +23,14 @@ object BuildkiteWebhookAdapter {
                 parseBuildFinished(w)
             }
 
+            "ping" -> {
+                GenericEvent(
+                    typeKey = "buildkite_ping",
+                    metadata = emptyMap(),
+                    rawPayload = emptyMap(),
+                )
+            }
+
             else -> {
                 GenericEvent(
                     typeKey = w.event ?: "buildkite_event",

--- a/api/src/main/kotlin/com/notifier/router/api/config/DataSeeder.kt
+++ b/api/src/main/kotlin/com/notifier/router/api/config/DataSeeder.kt
@@ -233,6 +233,13 @@ class DataSeeder(
                             createFilter("00000000-0000-0000-0000-000000000010", "author"),
                             createFilter("00000000-0000-0000-0000-000000000010", "repo"),
                         ),
+                    // Buildkite Ping
+                    createType(
+                        "00000000-0000-0000-0000-000000000011",
+                        "buildkite_ping",
+                        "Buildkite Ping",
+                        "Triggered when Buildkite sends a webhook ping (connection confirmed)",
+                    ) to emptyList(),
                 )
             }
     }

--- a/api/src/main/kotlin/com/notifier/router/api/controller/WebhookController.kt
+++ b/api/src/main/kotlin/com/notifier/router/api/controller/WebhookController.kt
@@ -5,6 +5,7 @@ import com.notifier.router.api.adapter.GitHubActionsWebhookAdapter
 import com.notifier.router.api.adapter.GitHubWebhookAdapter
 import com.notifier.router.api.domain.NotificationEvent
 import com.notifier.router.api.service.EventService
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -24,6 +25,8 @@ class WebhookController(
     @Value("\${github.webhook.secret:}") private val githubSecret: String,
     @Value("\${buildkite.webhook.token:}") private val buildkiteToken: String,
 ) {
+    private val logger = LoggerFactory.getLogger(WebhookController::class.java)
+
     @PostMapping("/github")
     fun handleGitHubWebhook(
         @RequestHeader("X-Hub-Signature-256") signature: String?,
@@ -48,7 +51,18 @@ class WebhookController(
         if (!verifyBuildkiteToken(token)) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
         }
-        return parseAndProcess { BuildkiteWebhookAdapter.parse(payload) }
+        return try {
+            val event = BuildkiteWebhookAdapter.parse(payload)
+            if (event.typeKey == "buildkite_ping") {
+                logger.info("Received Buildkite ping — webhook connection confirmed")
+                eventService.processEventAsync(event)
+                return ResponseEntity.ok().build()
+            }
+            eventService.processEventAsync(event)
+            ResponseEntity.accepted().build()
+        } catch (_: Exception) {
+            ResponseEntity.badRequest().build()
+        }
     }
 
     private fun parseAndProcess(parse: () -> NotificationEvent): ResponseEntity<Void> =

--- a/api/src/test/kotlin/com/notifier/router/api/controller/BuildkiteWebhookTokenIntegrationTest.kt
+++ b/api/src/test/kotlin/com/notifier/router/api/controller/BuildkiteWebhookTokenIntegrationTest.kt
@@ -73,4 +73,27 @@ class BuildkiteWebhookTokenIntegrationTest : BaseIntegrationTest() {
             .expectStatus()
             .isUnauthorized
     }
+
+    @Test
+    fun `POST buildkite ping with valid token returns 200`() {
+        val pingPayload =
+            """
+            {
+              "event": "ping",
+              "service": { "id": "abc", "provider": "webhook" },
+              "organization": { "slug": "my-org" },
+              "sender": { "name": "Test User" }
+            }
+            """.trimIndent()
+
+        restTemplate
+            .post()
+            .uri("/api/v1/webhooks/buildkite")
+            .contentType(MediaType.APPLICATION_JSON)
+            .header("X-Buildkite-Token", "integration-test-token")
+            .body(pingPayload)
+            .exchange()
+            .expectStatus()
+            .isOk
+    }
 }

--- a/api/src/test/kotlin/com/notifier/router/api/controller/WebhookControllerTest.kt
+++ b/api/src/test/kotlin/com/notifier/router/api/controller/WebhookControllerTest.kt
@@ -137,4 +137,22 @@ class WebhookControllerTest {
         assert(response.statusCode == HttpStatus.ACCEPTED)
         verify(eventService).processEventAsync(any())
     }
+
+    @Test
+    fun `handleBuildkiteWebhook returns Ok for ping and dispatches event`() {
+        val pingPayload =
+            """
+            {
+              "event": "ping",
+              "service": { "id": "abc", "provider": "webhook" },
+              "organization": { "slug": "my-org" },
+              "sender": { "name": "Test User" }
+            }
+            """.trimIndent()
+
+        val response = webhookController.handleBuildkiteWebhook(testBuildkiteToken, pingPayload)
+
+        assert(response.statusCode == HttpStatus.OK)
+        verify(eventService).processEventAsync(any())
+    }
 }

--- a/novu/workflows/buildkite-ping.json
+++ b/novu/workflows/buildkite-ping.json
@@ -1,0 +1,28 @@
+{
+    "name": "Buildkite Ping",
+    "identifier": "buildkite_ping",
+    "description": "Triggered when Buildkite sends a webhook ping (connection confirmed)",
+    "active": true,
+    "draft": false,
+    "preferenceSettings": {
+        "email": true,
+        "sms": true,
+        "in_app": true,
+        "push": true,
+        "chat": true
+    },
+    "steps": [
+        {
+            "name": "In-App Notification",
+            "uuid": "in-app-step-buildkite-ping",
+            "template": {
+                "type": "inApp",
+                "content": "Buildkite webhook ping received — connection confirmed",
+                "variables": []
+            },
+            "active": true,
+            "filters": []
+        }
+    ],
+    "__version": "1.0.0"
+}


### PR DESCRIPTION
…ation type (#12)

- BuildkiteWebhookAdapter: add explicit "ping" branch → GenericEvent(typeKey="buildkite_ping") to avoid accessing pipeline.slug on a payload that has no pipeline field
- WebhookController: parse event before dispatching; ping returns 200 OK (not 202) while still calling processEventAsync so subscribers receive the notification
- DataSeeder: seed buildkite_ping notification type (id 00000000-...0011, no filters)
- novu/workflows/buildkite-ping.json: Novu workflow definition for the ping event
- Tests: update WebhookControllerTest ping assertion (now verifies processEventAsync IS called); add ping integration test to BuildkiteWebhookTokenIntegrationTest