### PR TITLE
chore: remove stale novu/workflows reference from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,6 @@ GitHub Webhook / GitHub Actions / Buildkite
 | `bot/` | Slack Bolt bot — slash commands, modals, subscription management |
 | `common/` | Shared domain models with JPA annotations |
 | `docs/` | Architecture, API spec, DB schema, local dev guide |
-| `novu/workflows/` | Novu JSON workflow definitions |
 | `scripts/` | Setup scripts for Novu seeding |
 
 ## Key Files


### PR DESCRIPTION
The `novu/workflows/` directory was removed in #72. This removes the stale reference to it in CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)