### PR TITLE
fix: use title as email subject to avoid newline rejection by Resend

### DIFF
--- a/api/src/main/kotlin/com/notifier/router/api/config/NovuSeeder.kt
+++ b/api/src/main/kotlin/com/notifier/router/api/config/NovuSeeder.kt
@@ -38,12 +38,17 @@ class NovuSeeder(
         val existingWorkflows = novuService.listExistingWorkflowNames()
         types.forEach { type ->
             WORKFLOW_CHANNELS.forEach { channel ->
-                novuService.ensureChannelWorkflowExists(
-                    typeKey = type.typeKey,
-                    name = type.name,
-                    channel = channel,
-                    existingNames = existingWorkflows,
-                )
+                try {
+                    novuService.ensureChannelWorkflowExists(
+                        typeKey = type.typeKey,
+                        name = type.name,
+                        channel = channel,
+                        existingNames = existingWorkflows,
+                    )
+                } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+                    // Novu plan limits (e.g. workflow cap) must not prevent startup.
+                    logger.warn("Could not provision Novu workflow for ${type.typeKey}/$channel: ${e.message}")
+                }
             }
         }
 

--- a/api/src/main/kotlin/com/notifier/router/api/service/NovuService.kt
+++ b/api/src/main/kotlin/com/notifier/router/api/service/NovuService.kt
@@ -226,7 +226,7 @@ class NovuService(
         request.to = subscriberIds
         val enrichedPayload = payload.toMutableMap()
         if ("subject" !in enrichedPayload) {
-            enrichedPayload["subject"] = enrichedPayload["content"] ?: "Notification"
+            enrichedPayload["subject"] = enrichedPayload["title"] ?: "Notification"
         }
         request.payload = enrichedPayload
 
@@ -264,7 +264,7 @@ class NovuService(
         request.to = subscriberIds
         val enrichedPayload = payload.toMutableMap()
         if ("subject" !in enrichedPayload) {
-            enrichedPayload["subject"] = enrichedPayload["content"] ?: "Notification"
+            enrichedPayload["subject"] = enrichedPayload["title"] ?: "Notification"
         }
         request.payload = enrichedPayload
 


### PR DESCRIPTION
## Summary

- Email deliveries were failing with `"The \n is not allowed in the subject field"` from Resend
- Root cause: the email `subject` payload field fell back to `content`, which contains multi-line mrkdwn text (`\n` newlines)
- Fix: use `title` as the subject fallback in both `triggerEvent` and `triggerChannelWorkflow` — it's always a clean single-line string
- Also makes `NovuSeeder` resilient to Novu plan limits (workflow cap) so the app no longer crashes on startup when the limit is hit

## Test plan

- [ ] Open a PR on the repo
- [ ] Verify email is received with the PR title as subject (no `\n` error in Novu logs)
- [ ] Verify Slack DM still delivered correctly
- [ ] Restart API with Novu at workflow cap — confirm startup completes with a WARN log instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)