### PR TITLE
fix: create Slack endpoint for channel subscriptions from admin UI

### DIFF
--- a/api/src/main/resources/static/index.html
+++ b/api/src/main/resources/static/index.html
@@ -1597,6 +1597,8 @@ const Channels = {
           enabled: true,
         }),
       });
+      // Create Slack endpoint so Novu can deliver to the channel
+      try { await fetch(`${API}/subscribers/${encodeURIComponent(channelId)}/slack/endpoint`, { method: 'POST' }); } catch {}
       toast('Channel subscription created');
       closeModal();
       this.load();


### PR DESCRIPTION
## Summary
Channel subscriptions created from the admin dashboard were not creating the Novu Slack channel endpoint, causing notifications to never be delivered to the Slack channel.

## Changes
- `index.html`: call `POST /subscribers/{channelId}/slack/endpoint` after creating a channel subscription, matching the pattern already used for user subscriptions and the bot

## Test plan
- [ ] Admin dashboard → Channels tab → enter a Slack channel ID → Add subscription
- [ ] Send a test event matching the subscription's filters
- [ ] Verify the notification appears in the Slack channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)