### PR TITLE
config: wire GITHUB_WEBHOOK_SECRET and NOVU_API_KEY from environment (#108)

### DIFF
--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -28,6 +28,10 @@ app:
     # false (default): only re-seeds static notification types and filter definitions.
     full-reset: true
 
+github:
+  webhook:
+    secret: ${GITHUB_WEBHOOK_SECRET:}
+
 buildkite:
   webhook:
     token: ${BUILDKITE_WEBHOOK_TOKEN:}
@@ -36,7 +40,7 @@ buildkite:
 novu:
   api:
     url: http://localhost:3000/v1
-    key: nvsk.local_development_api_key_for_testing_purposes_only_12345
+    key: ${NOVU_API_KEY:nvsk.local_development_api_key_for_testing_purposes_only_12345}
   slack:
     client-id: ${SLACK_CLIENT_ID:}
     client-secret: ${SLACK_CLIENT_SECRET:}


### PR DESCRIPTION
## Summary

- Adds `github.webhook.secret: ${GITHUB_WEBHOOK_SECRET:}` — the property was already read by `WebhookController` via `@Value` but had no YAML mapping, so the env var was silently ignored
- Changes `novu.api.key` from a hardcoded value to `${NOVU_API_KEY:nvsk.local_development_api_key_for_testing_purposes_only_12345}` — the fallback preserves the existing local-dev behaviour when `.env` is absent

Both follow the same `${ENV_VAR:default}` convention already used for Buildkite (`BUILDKITE_WEBHOOK_TOKEN`) and Slack (`SLACK_CLIENT_ID`, etc.).

No Kotlin changes required.

Closes #108

## Test plan

- [ ] Start API locally with `.env` present — verify no startup errors and GitHub HMAC verification works
- [ ] Remove `NOVU_API_KEY` from env — verify fallback key is used and Novu integration starts normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)